### PR TITLE
SubnetID is required when using EMR notebooks

### DIFF
--- a/Setting_Spark_Cluster_In_AWS/exercises/starter/create_emr_cluster/Exercise_Creating_EMR_Clusters.py
+++ b/Setting_Spark_Cluster_In_AWS/exercises/starter/create_emr_cluster/Exercise_Creating_EMR_Clusters.py
@@ -21,7 +21,7 @@ aws emr create-cluster
 --instance-count 2 
 --applications Name=Spark  
 --bootstrap-actions Path=<YOUR_BOOTSTRAP_FILENAME> 
---ec2-attributes KeyName=<YOUR_KEY_NAME> 
+--ec2-attributes KeyName=<YOUR_KEY_NAME>,SubnetId=subnet-<SUBNET_ID>
 --instance-type m5.xlarge 
 --instance-count 3 
 --auto-terminate`


### PR DESCRIPTION
Module 4 - Data Lakes with Spark / Lesson 3 - Setting up Spark clusters with AWS

In section 6 is mentioned using EMR Notebooks but with the current instructions it doesn't work, you need to add the appropriate VPC for connecting.

Reference: https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-managed-notebooks-considerations.html

```
The cluster must be launched within an EC2-VPC. Public and private subnets are supported. The EC2-Classic platform is not supported.
```